### PR TITLE
feat: ajout des tableaux de métadonnées et des mockups wikibase

### DIFF
--- a/src/components/Ontology.js
+++ b/src/components/Ontology.js
@@ -1,0 +1,80 @@
+import React from 'react';
+
+const IsCapitalized = (string) => {
+  let first_letter = string[0];
+  return first_letter == first_letter.toUpperCase()
+}
+
+const GetPrefix = (string) => {
+  if (!string) {
+    return false
+  }
+
+  let splited_string = string.split(":");
+  if (splited_string.length == 2) {
+    return splited_string[0]
+  } else {
+    return null
+  }
+}
+
+const LinkClassOrProperty = (context, value) => {
+  const linking_contexts = ["rdfs:domain", "rdfs:range", "pq", "rdfs:subClassOf"];
+  const allowed_prefix = ["mov", null];
+
+  if (linking_contexts.includes(context) && allowed_prefix.includes(GetPrefix(value))) {
+    if (IsCapitalized(value)) {
+      return <a href={"/Ontologie/Classes/" + value}>{value}</a>
+    } else {
+      return <a href={"/Ontologie/Propriétés/" + value}>{value}</a>
+    }
+  } else {
+    return value
+  }
+}
+
+const FormatQualifier = (context, value) => {
+  const format_contexts = ["pq"];
+
+  if (!value) {
+    return value
+  }
+
+  if (format_contexts.includes(context)) {
+    return <>{" "}<code>{value}</code></>
+  } else {
+    return value
+  }
+}
+
+export const OntologyTable = ({ frontMatter }) => (
+  <table>
+    <thead>
+      <tr>
+        {
+          Object.keys(frontMatter["owl"])
+          .map((keys) =>
+            <th>
+              {keys}
+            </th>
+          )
+        }
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        {Object.entries(frontMatter["owl"])
+          .map(([key, value]) => {
+            return <td>
+              {
+                [value].flat().map(value => {
+                  return FormatQualifier(key, LinkClassOrProperty(key, value))
+                })
+              }
+            </td>
+          }
+          )}
+      </tr>
+    </tbody>
+  </table>
+);

--- a/src/components/WbMockup.js
+++ b/src/components/WbMockup.js
@@ -1,0 +1,57 @@
+import React from 'react';
+
+const Claim = ({ emphase=false, property, children }) => {
+  return (<div class="wb-container">
+    <div class="claim-container">
+      <a class={` ${emphase ? "emphase" : ""}`} href={"/Ontologie/Propriétés/" + property}>{property}</a>
+    </div>
+    <div class="statements-container">
+      {children}
+    </div>
+  </div>)
+};
+
+const Statement = ({emphase=false, value, children }) => {
+  return (<div class={`statement ${emphase ? "emphase" : ""}`}>
+    <div class="value">
+      {value}
+    </div>
+    {children}
+  </div>)
+};
+
+const References = ({ children }) => {
+  return (<div class="references-container">
+    <a>▾ référence</a>
+    {children}
+  </div>)
+};
+
+const Reference = ({ children }) => {
+  return (<div class="references-container">
+    <div class="references">
+      {children}
+    </div>
+  </div>)
+};
+
+const ReferenceElement = ({ emphase=false, property, children }) => {
+  return (<div>
+    <div class={`property ${emphase ? "emphase" : ""}`}>
+      <a href={"/Ontologie/Propriétés/" + property}>{property}</a>
+    </div>
+    <span >
+      {children}
+    </span>
+  </div>)
+};
+
+const Qualifier = ({ emphase=false, property, children }) => {
+  return (<div class={`qualifier-container ${emphase ? "emphase" : ""}`}>
+    <div>
+      <span class="property"><a href={"/Ontologie/Propriétés/" + property}>{property}</a></span><span class="qualifier-value"> {children}</span>
+    </div>
+  </div>)
+};
+
+export { Claim, Statement, Qualifier, References, Reference, ReferenceElement };

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -15,6 +15,8 @@
   --ifm-color-primary-lightest: #3cad6e;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  --wb-claim-container: #eaecf0;
+  --references-container: #f8f9fa;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
@@ -27,4 +29,104 @@
   --ifm-color-primary-lighter: #32d8b4;
   --ifm-color-primary-lightest: #4fddbf;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+  --wb-claim-container: #1f2020;
+  --references-container: #262626;
+}
+
+.emphase {
+  border: 0.5px solid var(--ifm-color-primary);
+}
+
+.wb-container {
+  display: flex;
+  min-width: 100%;
+  border: 1px solid #c8ccd1
+}
+
+.wb-container + .wb-container {
+  margin-top: 33px;
+}
+
+.wb-container > * {
+  padding-top: 5px;
+}
+
+.wb-container a {
+  color: #104db0;
+}
+
+.claim-container a {
+  color: #104db0;
+  padding-left: 5px;
+  padding-right: 5px;
+  position: -webkit-sticky;  
+  position: sticky;
+  top: 70px;
+}
+
+.claim-container {
+  background-color: var(--wb-claim-container);
+  width: 30%;
+  float: left;
+  padding-left: 10px;
+  padding-bottom: 10px;
+}
+
+.statements-container {
+  float: right;
+  width: 100%;
+  margin-bottom: 1px;
+  font-size: 14px;
+}
+
+.statements-container > * {
+  padding-left: 20px;
+}
+
+.statement {
+  padding-bottom: 20px;
+}
+
+.statement + .statement {
+  border-top: 0.2px solid #c8ccd1
+}
+
+.qualifier-container {
+  padding-left: 20px;
+  
+}
+
+.qualifier-container .property {
+  color: #104db0;
+  width: 220px;
+  display: inline-block;
+  font-size: 90%;
+}
+
+.qualifier-container .qualifier-value {
+  width: 220px;
+  display: inline-block;
+  font-size: calc(1em * 0.875);
+}
+
+.references-container {
+  padding-left: 20px;
+  padding-top: 10px;
+}
+
+.references {
+  font-size: small;
+  padding: 7px;
+  background-color: var(--references-container);
+}
+
+.references-container a {
+  color: #104db0;
+}
+
+.references .property {
+  color: #104db0;
+  width: 220px;
+  display: inline-block;
+  font-size: 12.6px;
 }

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import MDXComponents from '@theme-original/MDXComponents';
+import {Claim, Qualifier, Statement, References, Reference, ReferenceElement} from '@site/src/components/WbMockup';
+import { OntologyTable } from '@site/src/components/Ontology';
+
+export default {
+    ...MDXComponents,
+    Claim: Claim,
+    Qualifier: Qualifier,
+    Statement: Statement,
+    References: References,
+    Reference: Reference,
+    ReferenceElement: ReferenceElement,
+    OntologyTable: OntologyTable
+};


### PR DESCRIPTION
Cette pull request ajoute :

La génération des mockups wikibase dans la documentation : 
![image](https://github.com/abes-esr/movies-documentation/assets/60341438/431494df-9a6b-49f7-8a3d-ac059c47fa4a)

La génération des tableaux de métadonnées pour les classes et les propriétés à partir de l'entête des fichiers markdown  :

![image](https://github.com/abes-esr/movies-documentation/assets/60341438/c0675772-6059-4f0d-91f1-dc2d969e04f0)
